### PR TITLE
Allow comments, etc. in update.cfg

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -53,7 +53,15 @@ Boilerplate files are organized into "conventions". Different services require d
 
 To opt into a convention, configure ``boilerplate/update.cfg`` with the conventions that you'd like to opt in to. The convention files live in `<https://github.com/lyft/boilerplate/tree/master/boilerplate>`_ and are specified in the format ``{namespace}/{convention}`` 
 
-For example, to opt-into lyft's ``docker_build`` file, add ``lyft/docker_build`` to your ``boilerplate/update.cfg`` file.
+For example, to opt-into lyft's ``docker_build`` and ``golangci_file`` conventions, your ``boilerplate/update.cfg`` file might look like this:
+
+::
+
+  # Use standard docker build targets
+  lyft/docker_build
+  
+  # Common linting configuration for golang
+  lyft/golangci_file
 
 below is a full list of available conventions.
 

--- a/boilerplate/update.sh
+++ b/boilerplate/update.sh
@@ -10,6 +10,8 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 OUT="$(mktemp -d)"
+trap "rm -fr $OUT" EXIT
+
 git clone git@github.com:flyteorg/boilerplate.git "${OUT}"
 
 echo "Updating the update.sh script."
@@ -33,13 +35,34 @@ if [ -z "$REPOSITORY" ]; then
   exit 1
 fi
 
-while read directory; do
-  # TODO: Skip empty lines, whitespace only lines, and comment lines
+while read directory junk; do
+  # Skip comment lines (which can have leading whitespace)
+  if [[ "$directory" == '#'* ]]; then
+    continue
+  fi
+  # Skip blank or whitespace-only lines
+  if [[ "$directory" == "" ]]; then
+    continue
+  fi
+  # Lines like
+  #    valid/path  other_junk
+  # are not acceptable, unless `other_junk` is a comment
+  if [[ "$junk" != "" ]] && [[ "$junk" != '#'* ]]; then
+    echo "Invalid config! Only one directory is allowed per line. Found '$junk'"
+    exit 1
+  fi
+
+  dir_path="${OUT}/boilerplate/${directory}"
+  # Make sure the directory exists
+  if ! [[ -d "$dir_path" ]]; then
+    echo "Invalid boilerplate directory: '$directory'"
+    exit 1
+  fi
+
   echo "***********************************************************************************"
   echo "$directory is configured in update.cfg."
   echo "-----------------------------------------------------------------------------------"
   echo "syncing files from source."
-  dir_path="${OUT}/boilerplate/${directory}"
   rm -rf "${DIR}/${directory}"
   mkdir -p $(dirname "${DIR}/${directory}")
   cp -r "$dir_path" "${DIR}/${directory}"
@@ -50,5 +73,3 @@ while read directory; do
   echo "***********************************************************************************"
   echo ""
 done < "$CONFIG_FILE"
-
-rm -rf "${OUT}"


### PR DESCRIPTION
This addresses a TODO in `update.sh` to allow a more freeform `update.cfg`. With this change, `update.cfg` will:

- Tolerate and ignore blank/whitespace-only lines
- Tolerate `#` style comments, both inline (as long as preceded by whitespace) and whole-line.
- Validate directories more prettily, failing with a useful message if one doesn't exist.
- Explicitly disallow multiple entries per line, with a useful message.

(Previously these last two things would still error, just more confusingly.)

While in there, I also added an `EXIT` trap to remove the temporary directory, since otherwise failures mid-script would leave it hanging around, gradually polluting `/tmp`.