### PR TITLE
Excluded boilerplate dir from goimport

### DIFF
--- a/boilerplate/flyte/golang_test_targets/goimports
+++ b/boilerplate/flyte/golang_test_targets/goimports
@@ -5,4 +5,4 @@
 # 
 # TO OPT OUT OF UPDATES, SEE https://github.com/flyteorg/boilerplate/blob/master/Readme.rst
 
-goimports -w $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/client/*")
+goimports -w $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/client/*" -not -path "./boilerplate/*")


### PR DESCRIPTION
- Excluded boilerplate dir from goimport


fix: https://github.com/flyteorg/flyte/issues/1225