### PR TITLE
Fix boilerplate/end2end to install the compiled kustomize manifest

### DIFF
--- a/boilerplate/flyte/end2end/end2end.sh
+++ b/boilerplate/flyte/end2end/end2end.sh
@@ -30,5 +30,7 @@ then
 fi
 
 make kustomize
+# launch flyte end2end
+kubectl apply -f "${OUT}/deployment/test/flyte_generated.yaml"
 make end2end_execute
 popd


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

this [commit](https://github.com/flyteorg/flyte/commit/697dbd741cb0d82e5f9ccfd3c9b61f293d1f9a4c#diff-3389e2c537388e9744c4bdb3ffca7339d9c4d3e07f7e0b16fe814ac123f21dd8L16-L23) Changed how end to end tests run to allow both kustomize and helm to be tested. There needs to be a corresponding change in boilerplate (and all repos that use that)