### PR TITLE
Bump versions of golang and alpine

### DIFF
--- a/boilerplate/flyte/golang_dockerfile/Dockerfile.GoTemplate
+++ b/boilerplate/flyte/golang_dockerfile/Dockerfile.GoTemplate
@@ -3,7 +3,7 @@
 # 
 # TO OPT OUT OF UPDATES, SEE https://github.com/flyteorg/boilerplate/blob/master/Readme.rst
 
-FROM golang:1.13.3-alpine3.10 as builder
+FROM golang:1.17.1-alpine3.14 as builder
 RUN apk add git openssh-client make curl
 
 # COPY only the go mod files for efficient caching
@@ -30,7 +30,7 @@ RUN curl --silent --fail --show-error --location --output /artifacts/grpc_health
 ENV PATH="/artifacts:${PATH}"
 
 # This will eventually move to centurylink/ca-certs:latest for minimum possible image size
-FROM alpine:3.10
+FROM alpine:3.14
 COPY --from=builder /artifacts /bin
 
 RUN apk --update add ca-certificates


### PR DESCRIPTION
Bumping versions to what's already been in use in flyteadmin.

This should take care of the [CVE](https://nvd.nist.gov/vuln/detail/CVE-2021-36159) in alpine-3.10