### PR TITLE
Removed kustomize steps from script in end2end

### DIFF
--- a/boilerplate/flyte/end2end/end2end.sh
+++ b/boilerplate/flyte/end2end/end2end.sh
@@ -13,5 +13,7 @@ OUT="${DIR}/tmp"
 rm -rf ${OUT}
 git clone https://github.com/flyteorg/flyte.git "${OUT}"
 
+pushd ${OUT}
+
 make end2end_execute
 popd

--- a/boilerplate/flyte/end2end/end2end.sh
+++ b/boilerplate/flyte/end2end/end2end.sh
@@ -13,24 +13,5 @@ OUT="${DIR}/tmp"
 rm -rf ${OUT}
 git clone https://github.com/flyteorg/flyte.git "${OUT}"
 
-pushd ${OUT}
-
-if [ ! -z "$IMAGE" ]; 
-then
-  kind load docker-image ${IMAGE}
-  if [ "${IMAGE_NAME}" == "flytepropeller" ]
-  then
-    sed -i.bak -e "s_${IMAGE_NAME}:.*_${IMAGE}_g" "${OUT}"/kustomize/base/propeller/deployment.yaml
-  fi
-
-  if [ "${IMAGE_NAME}" == "flyteadmin" ]
-  then
-    sed -i.bak -e "s_${IMAGE_NAME}:.*_${IMAGE}_g" "${OUT}"/kustomize/base/admindeployment/deployment.yaml
-  fi
-fi
-
-make kustomize
-# launch flyte end2end
-kubectl apply -f "${OUT}/deployment/test/flyte_generated.yaml"
 make end2end_execute
 popd


### PR DESCRIPTION
We started moving changes for replacing kind cluster from flytectl sandbox, Now we also have option for upgrading the component image.  

Dependent PR :
- https://github.com/flyteorg/flyteadmin/pull/293
- https://github.com/flyteorg/flytepropeller/pull/350 

Changes:
Just removed the kustomize deployment with helm.