### PR TITLE
Getting the latest golangcli-lint to fix broken executable on mac

### DIFF
--- a/boilerplate/flyte/golang_test_targets/download_tooling.sh
+++ b/boilerplate/flyte/golang_test_targets/download_tooling.sh
@@ -18,7 +18,7 @@ set -e
 tools=(
   "github.com/vektra/mockery/cmd/mockery"
   "github.com/flyteorg/flytestdlib/cli/pflags"
-  "github.com/golangci/golangci-lint/cmd/golangci-lint"
+  "github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
   "github.com/alvaroloes/enumer"
   "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
 )


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

### Without the change 
```
make -f  boilerplate/flyte/golang_test_targets/Makefile download_tooling 
Using temp directory /var/folders/fw/3_xpq9s53l10pj6s2j2fs0v40000gn/T/gotooling-XXX.9hNAtxoX
/var/folders/fw/3_xpq9s53l10pj6s2j2fs0v40000gn/T/gotooling-XXX.9hNAtxoX ~/boilerplate
Installing github.com/vektra/mockery/cmd/mockery
Installing github.com/flyteorg/flytestdlib/cli/pflags
Installing github.com/golangci/golangci-lint/cmd/golangci-lint
Installing github.com/alvaroloes/enumer
Installing github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
~/boilerplate
(base) ➜  boilerplate git:(master) golangci-lint version
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb01dfacedebac1e pc=0x7fff2064dcbe]

runtime stack:
runtime: unexpected return pc for runtime.sigpanic called from 0x7fff2064dcbe
stack: frame={sp:0x7ffeefbff608, fp:0x7ffeefbff658} stack=[0x7ffeefb806a8,0x7ffeefbff710)
0x00007ffeefbff508:  0x01007ffeefbff528  0x0000000000000004 
0x00007ffeefbff518:  0x000000000000001f  0x00007fff2064dcbe 
0x00007ffeefbff528:  0x0b01dfacedebac1e  0x0000000000000001 
0x00007ffeefbff538:  0x00000000040371f1 <runtime.throw+0x0000000000000071>  0x00007ffeefbff5d8 
0x00007ffeefbff548:  0x0000000004acd340  0x00007ffeefbff590 
0x00007ffeefbff558:  0x00000000040374a8 <runtime.fatalthrow.func1+0x0000000000000048>  0x0000000005356fc0 
0x00007ffeefbff568:  0x0000000000000001  0x0000000000000001 
0x00007ffeefbff578:  0x00007ffeefbff5d8  0x00000000040371f1 <runtime.throw+0x0000000000000071> 
0x00007ffeefbff588:  0x0000000005356fc0  0x00007ffeefbff5c8 
0x00007ffeefbff598:  0x0000000004037430 <runtime.fatalthrow+0x0000000000000050>  0x00007ffeefbff5a8 
0x00007ffeefbff5a8:  0x0000000004037460 <runtime.fatalthrow.func1+0x0000000000000000>  0x0000000005356fc0 
0x00007ffeefbff5b8:  0x00000000040371f1 <runtime.throw+0x0000000000000071>  0x00007ffeefbff5d8 
0x00007ffeefbff5c8:  0x00007ffeefbff5f8  0x00000000040371f1 <runtime.throw+0x0000000000000071> 
0x00007ffeefbff5d8:  0x00007ffeefbff5e0  0x0000000004037220 <runtime.throw.func1+0x0000000000000000> 
0x00007ffeefbff5e8:  0x0000000004adc420  0x000000000000002a 
0x00007ffeefbff5f8:  0x00007ffeefbff648  0x000000000404d6d6 <runtime.sigpanic+0x0000000000000396> 
0x00007ffeefbff608: <0x0000000004adc420  0x000000c00019a000 
0x00007ffeefbff618:  0x00007ffeefbff688  0x0000000004029266 <runtime.(*mheap).allocSpan+0x0000000000000546> 
0x00007ffeefbff628:  0x000000c00019a000  0x0000000000002000 
0x00007ffeefbff638:  0x000000c000000008  0x0000000000000000 
0x00007ffeefbff648:  0x00007ffeefbff690 !0x00007fff2064dcbe 
0x00007ffeefbff658: >0x00007ffeefbff690  0x00000000051b4000 
0x00007ffeefbff668:  0x000000000000036a  0x00000000042a83a5 <golang.org/x/sys/unix.libc_ioctl_trampoline+0x0000000000000005> 
0x00007ffeefbff678:  0x000000000406c77f <runtime.syscall+0x000000000000001f>  0x000000c000197848 
0x00007ffeefbff688:  0x00007ffeefbff6d0  0x000000c000197818 
0x00007ffeefbff698:  0x000000000406a5b0 <runtime.asmcgocall+0x0000000000000070>  0x0000000000000001 
0x00007ffeefbff6a8:  0x0000000004013f00 <runtime.evacuate_fast32+0x00000000000003a0>  0x3f00000000001018 
0x00007ffeefbff6b8:  0x0000000000000000  0x0000000005394cf8 
0x00007ffeefbff6c8:  0x0000000000000810  0x000000c0000001a0 
0x00007ffeefbff6d8:  0x00000000040686c9 <runtime.systemstack+0x0000000000000049>  0x0000000000000004 
0x00007ffeefbff6e8:  0x0000000004bfc678  0x0000000005356fc0 
0x00007ffeefbff6f8:  0x00007ffeefbff748  0x00000000040685c5 <runtime.mstart+0x0000000000000005> 
0x00007ffeefbff708:  0x000000000406857d <runtime.rt0_go+0x000000000000013d> 
runtime.throw({0x4adc420, 0xc00019a000})
	/usr/local/Cellar/go/1.17.6/libexec/src/runtime/panic.go:1198 +0x71
runtime: unexpected return pc for runtime.sigpanic called from 0x7fff2064dcbe
stack: frame={sp:0x7ffeefbff608, fp:0x7ffeefbff658} stack=[0x7ffeefb806a8,0x7ffeefbff710)
0x00007ffeefbff508:  0x01007ffeefbff528  0x0000000000000004 
0x00007ffeefbff518:  0x000000000000001f  0x00007fff2064dcbe 
0x00007ffeefbff528:  0x0b01dfacedebac1e  0x0000000000000001 
0x00007ffeefbff538:  0x00000000040371f1 <runtime.throw+0x0000000000000071>  0x00007ffeefbff5d8 
0x00007ffeefbff548:  0x0000000004acd340  0x00007ffeefbff590 
0x00007ffeefbff558:  0x00000000040374a8 <runtime.fatalthrow.func1+0x0000000000000048>  0x0000000005356fc0 
0x00007ffeefbff568:  0x0000000000000001  0x0000000000000001 
0x00007ffeefbff578:  0x00007ffeefbff5d8  0x00000000040371f1 <runtime.throw+0x0000000000000071> 
0x00007ffeefbff588:  0x0000000005356fc0  0x00007ffeefbff5c8 
0x00007ffeefbff598:  0x0000000004037430 <runtime.fatalthrow+0x0000000000000050>  0x00007ffeefbff5a8 
0x00007ffeefbff5a8:  0x0000000004037460 <runtime.fatalthrow.func1+0x0000000000000000>  0x0000000005356fc0 
0x00007ffeefbff5b8:  0x00000000040371f1 <runtime.throw+0x0000000000000071>  0x00007ffeefbff5d8 
0x00007ffeefbff5c8:  0x00007ffeefbff5f8  0x00000000040371f1 <runtime.throw+0x0000000000000071> 
0x00007ffeefbff5d8:  0x00007ffeefbff5e0  0x0000000004037220 <runtime.throw.func1+0x0000000000000000> 
0x00007ffeefbff5e8:  0x0000000004adc420  0x000000000000002a 
0x00007ffeefbff5f8:  0x00007ffeefbff648  0x000000000404d6d6 <runtime.sigpanic+0x0000000000000396> 
0x00007ffeefbff608: <0x0000000004adc420  0x000000c00019a000 
0x00007ffeefbff618:  0x00007ffeefbff688  0x0000000004029266 <runtime.(*mheap).allocSpan+0x0000000000000546> 
0x00007ffeefbff628:  0x000000c00019a000  0x0000000000002000 
0x00007ffeefbff638:  0x000000c000000008  0x0000000000000000 
0x00007ffeefbff648:  0x00007ffeefbff690 !0x00007fff2064dcbe 
0x00007ffeefbff658: >0x00007ffeefbff690  0x00000000051b4000 
0x00007ffeefbff668:  0x000000000000036a  0x00000000042a83a5 <golang.org/x/sys/unix.libc_ioctl_trampoline+0x0000000000000005> 
0x00007ffeefbff678:  0x000000000406c77f <runtime.syscall+0x000000000000001f>  0x000000c000197848 
0x00007ffeefbff688:  0x00007ffeefbff6d0  0x000000c000197818 
0x00007ffeefbff698:  0x000000000406a5b0 <runtime.asmcgocall+0x0000000000000070>  0x0000000000000001 
0x00007ffeefbff6a8:  0x0000000004013f00 <runtime.evacuate_fast32+0x00000000000003a0>  0x3f00000000001018 
0x00007ffeefbff6b8:  0x0000000000000000  0x0000000005394cf8 
0x00007ffeefbff6c8:  0x0000000000000810  0x000000c0000001a0 
0x00007ffeefbff6d8:  0x00000000040686c9 <runtime.systemstack+0x0000000000000049>  0x0000000000000004 
0x00007ffeefbff6e8:  0x0000000004bfc678  0x0000000005356fc0 
0x00007ffeefbff6f8:  0x00007ffeefbff748  0x00000000040685c5 <runtime.mstart+0x0000000000000005> 
0x00007ffeefbff708:  0x000000000406857d <runtime.rt0_go+0x000000000000013d> 
runtime.sigpanic()
	/usr/local/Cellar/go/1.17.6/libexec/src/runtime/signal_unix.go:719 +0x396

goroutine 1 [syscall, locked to thread]:
syscall.syscall(0x42a83a0, 0x1, 0x40487413, 0xc0001978d8)
	/usr/local/Cellar/go/1.17.6/libexec/src/runtime/sys_darwin.go:22 +0x3b fp=0xc000197848 sp=0xc000197828 pc=0x406717b
syscall.syscall(0x40b8366, 0x20, 0xc000197900, 0x40b8298)
	<autogenerated>:1 +0x26 fp=0xc000197890 sp=0xc000197848 pc=0x406cf46
golang.org/x/sys/unix.ioctl(0x4a34f34, 0x4, 0x100c000085900)
	/Users/praful/go/pkg/mod/golang.org/x/sys@v0.0.0-20210124154548-22da62e12c0c/unix/zsyscall_darwin_amd64.go:689 +0x39 fp=0xc0001978c0 sp=0xc000197890 pc=0x42a7c99
golang.org/x/sys/unix.IoctlGetTermios(...)
	/Users/praful/go/pkg/mod/golang.org/x/sys@v0.0.0-20210124154548-22da62e12c0c/unix/ioctl.go:72
github.com/mattn/go-isatty.IsTerminal(0x4a34f34)
	/Users/praful/go/pkg/mod/github.com/mattn/go-isatty@v0.0.12/isatty_bsd.go:10 +0x50 fp=0xc000197930 sp=0xc0001978c0 pc=0x42a84b0
github.com/fatih/color.init()
	/Users/praful/go/pkg/mod/github.com/fatih/color@v1.10.0/color.go:21 +0x7a fp=0xc000197968 sp=0xc000197930 pc=0x42aa9fa
runtime.doInit(0x51bc5e0)
	/usr/local/Cellar/go/1.17.6/libexec/src/runtime/proc.go:6498 +0x123 fp=0xc000197aa0 sp=0xc000197968 pc=0x4046c83
runtime.doInit(0x51bc700)
	/usr/local/Cellar/go/1.17.6/libexec/src/runtime/proc.go:6475 +0x71 fp=0xc000197bd8 sp=0xc000197aa0 pc=0x4046bd1
runtime.doInit(0x51bb800)
	/usr/local/Cellar/go/1.17.6/libexec/src/runtime/proc.go:6475 +0x71 fp=0xc000197d10 sp=0xc000197bd8 pc=0x4046bd1
runtime.doInit(0x51c5040)
	/usr/local/Cellar/go/1.17.6/libexec/src/runtime/proc.go:6475 +0x71 fp=0xc000197e48 sp=0xc000197d10 pc=0x4046bd1
runtime.doInit(0x51b8b20)
	/usr/local/Cellar/go/1.17.6/libexec/src/runtime/proc.go:6475 +0x71 fp=0xc000197f80 sp=0xc000197e48 pc=0x4046bd1
runtime.main()
	/usr/local/Cellar/go/1.17.6/libexec/src/runtime/proc.go:238 +0x1e6 fp=0xc000197fe0 sp=0xc000197f80 pc=0x4039b06
runtime.goexit()
	/usr/local/Cellar/go/1.17.6/libexec/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc000197fe8 sp=0xc000197fe0 pc=0x406a8a1
```

## With the change

```
make -f  boilerplate/flyte/golang_test_targets/Makefile download_tooling
Using temp directory /var/folders/fw/3_xpq9s53l10pj6s2j2fs0v40000gn/T/gotooling-XXX.vTpJpPt2
/var/folders/fw/3_xpq9s53l10pj6s2j2fs0v40000gn/T/gotooling-XXX.vTpJpPt2 ~/boilerplate
Installing github.com/vektra/mockery/cmd/mockery
Installing github.com/flyteorg/flytestdlib/cli/pflags
Installing github.com/golangci/golangci-lint/cmd/golangci-lint@latest
Installing github.com/alvaroloes/enumer
Installing github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
~/boilerplate
(base) ➜  boilerplate git:(master) ✗ golangci-lint version                                                   
golangci-lint has version v1.44.2 built from (unknown, mod sum: "h1:MzvkDt1j1OHkv42/feNJVNNXRFACPp7aAWBWDo5aYQw=") on (unknown)
```