### PR TITLE
Use click to define parameters to functional tests script and extra flag

### DIFF
--- a/boilerplate/flyte/end2end/end2end.sh
+++ b/boilerplate/flyte/end2end/end2end.sh
@@ -10,5 +10,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 LATEST_VERSION=$(curl --silent "https://api.github.com/repos/flyteorg/flytesnacks/releases/latest" | jq -r .tag_name)
 
-FLYTE_SDK_USE_STRUCTURED_DATASET=TRUE python ./boilerplate/flyte/end2end/run-tests.py $LATEST_VERSION P0,P1 ./boilerplate/flyte/end2end/functional-test.config core
-
+FLYTE_SDK_USE_STRUCTURED_DATASET=TRUE python ./boilerplate/flyte/end2end/run-tests.py $LATEST_VERSION P0,P1 ./boilerplate/flyte/end2end/functional-test.config --return_non_zero_on_failure

--- a/boilerplate/flyte/end2end/run-tests.py
+++ b/boilerplate/flyte/end2end/run-tests.py
@@ -11,45 +11,45 @@ from typing import List, Mapping, Tuple, Dict
 from flytekit.remote import FlyteRemote
 from flytekit.models.core.execution import WorkflowExecutionPhase
 
-WAIT_TIME = 3
-MAX_ATTEMPTS = 2
+WAIT_TIME = 10
+MAX_ATTEMPTS = 60
 
 # This dictionary maps the names found in the flytesnacks manifest to a list of workflow names and
 # inputs. This is so we can progressively cover all priorities in the original flytesnacks manifest,
 # starting with "core".
 FLYTESNACKS_WORKFLOW_GROUPS: Mapping[str, List[Tuple[str, dict]]] = {
     "core": [
-        # ("core.control_flow.chain_tasks.chain_tasks_wf", {}),
-        # ("core.control_flow.dynamics.wf", {"s1": "Pear", "s2": "Earth"}),
-        # ("core.control_flow.map_task.my_map_workflow", {"a": [1, 2, 3, 4, 5]}),
-        # # Workflows that use nested executions cannot be launched via flyteremote.
-        # # This issue is being tracked in https://github.com/flyteorg/flyte/issues/1482.
-        # # ("core.control_flow.run_conditions.multiplier", {"my_input": 0.5}),
-        # # ("core.control_flow.run_conditions.multiplier_2", {"my_input": 10}),
-        # # ("core.control_flow.run_conditions.multiplier_3", {"my_input": 5}),
-        # # ("core.control_flow.run_conditions.basic_boolean_wf", {"seed": 5}),
-        # # ("core.control_flow.run_conditions.bool_input_wf", {"b": True}),
-        # # ("core.control_flow.run_conditions.nested_conditions", {"my_input": 0.4}),
-        # # ("core.control_flow.run_conditions.consume_outputs", {"my_input": 0.4, "seed": 7}),
-        # # ("core.control_flow.run_merge_sort.merge_sort", {"numbers": [5, 4, 3, 2, 1], "count": 5}),
-        # ("core.control_flow.subworkflows.parent_wf", {"a": 3}),
-        # ("core.control_flow.subworkflows.nested_parent_wf", {"a": 3}),
+        ("core.control_flow.chain_tasks.chain_tasks_wf", {}),
+        ("core.control_flow.dynamics.wf", {"s1": "Pear", "s2": "Earth"}),
+        ("core.control_flow.map_task.my_map_workflow", {"a": [1, 2, 3, 4, 5]}),
+        # Workflows that use nested executions cannot be launched via flyteremote.
+        # This issue is being tracked in https://github.com/flyteorg/flyte/issues/1482.
+        # ("core.control_flow.run_conditions.multiplier", {"my_input": 0.5}),
+        # ("core.control_flow.run_conditions.multiplier_2", {"my_input": 10}),
+        # ("core.control_flow.run_conditions.multiplier_3", {"my_input": 5}),
+        # ("core.control_flow.run_conditions.basic_boolean_wf", {"seed": 5}),
+        # ("core.control_flow.run_conditions.bool_input_wf", {"b": True}),
+        # ("core.control_flow.run_conditions.nested_conditions", {"my_input": 0.4}),
+        # ("core.control_flow.run_conditions.consume_outputs", {"my_input": 0.4, "seed": 7}),
+        # ("core.control_flow.run_merge_sort.merge_sort", {"numbers": [5, 4, 3, 2, 1], "count": 5}),
+        ("core.control_flow.subworkflows.parent_wf", {"a": 3}),
+        ("core.control_flow.subworkflows.nested_parent_wf", {"a": 3}),
         ("core.flyte_basics.basic_workflow.my_wf", {"a": 50, "b": "hello"}),
+        # Getting a 403 for the wikipedia image
+        # ("core.flyte_basics.files.rotate_one_workflow", {"in_image": "https://upload.wikimedia.org/wikipedia/commons/d/d2/Julia_set_%28C_%3D_0.285%2C_0.01%29.jpg"}),
+        ("core.flyte_basics.folders.download_and_rotate", {}),
+        ("core.flyte_basics.hello_world.my_wf", {}),
+        ("core.flyte_basics.lp.my_wf", {"val": 4}),
+        ("core.flyte_basics.lp.go_greet", {"day_of_week": "5", "number": 3, "am": True}),
+        ("core.flyte_basics.named_outputs.my_wf", {}),
         # # Getting a 403 for the wikipedia image
-        # # ("core.flyte_basics.files.rotate_one_workflow", {"in_image": "https://upload.wikimedia.org/wikipedia/commons/d/d2/Julia_set_%28C_%3D_0.285%2C_0.01%29.jpg"}),
-        # ("core.flyte_basics.folders.download_and_rotate", {}),
-        # ("core.flyte_basics.hello_world.my_wf", {}),
-        # ("core.flyte_basics.lp.my_wf", {"val": 4}),
-        # ("core.flyte_basics.lp.go_greet", {"day_of_week": "5", "number": 3, "am": True}),
-        # ("core.flyte_basics.named_outputs.my_wf", {}),
-        # # # Getting a 403 for the wikipedia image
-        # # # ("core.flyte_basics.reference_task.wf", {}),
-        # ("core.type_system.custom_objects.wf", {"x": 10, "y": 20}),
-        # # Enums are not supported in flyteremote
-        # # ("core.type_system.enums.enum_wf", {"c": "red"}),
-        # ("core.type_system.schema.df_wf", {"a": 42}),
-        # ("core.type_system.typed_schema.wf", {}),
-        # ("my.imperative.workflow.example", {"in1": "hello", "in2": "foo"}),
+        # # ("core.flyte_basics.reference_task.wf", {}),
+        ("core.type_system.custom_objects.wf", {"x": 10, "y": 20}),
+        # Enums are not supported in flyteremote
+        # ("core.type_system.enums.enum_wf", {"c": "red"}),
+        ("core.type_system.schema.df_wf", {"a": 42}),
+        ("core.type_system.typed_schema.wf", {}),
+        ("my.imperative.workflow.example", {"in1": "hello", "in2": "foo"}),
     ],
 }
 

--- a/boilerplate/flyte/end2end/run-tests.py
+++ b/boilerplate/flyte/end2end/run-tests.py
@@ -11,45 +11,45 @@ from typing import List, Mapping, Tuple, Dict
 from flytekit.remote import FlyteRemote
 from flytekit.models.core.execution import WorkflowExecutionPhase
 
-WAIT_TIME = 10
-MAX_ATTEMPTS = 60
+WAIT_TIME = 3
+MAX_ATTEMPTS = 2
 
 # This dictionary maps the names found in the flytesnacks manifest to a list of workflow names and
 # inputs. This is so we can progressively cover all priorities in the original flytesnacks manifest,
 # starting with "core".
 FLYTESNACKS_WORKFLOW_GROUPS: Mapping[str, List[Tuple[str, dict]]] = {
     "core": [
-        ("core.control_flow.chain_tasks.chain_tasks_wf", {}),
-        ("core.control_flow.dynamics.wf", {"s1": "Pear", "s2": "Earth"}),
-        ("core.control_flow.map_task.my_map_workflow", {"a": [1, 2, 3, 4, 5]}),
-        # Workflows that use nested executions cannot be launched via flyteremote.
-        # This issue is being tracked in https://github.com/flyteorg/flyte/issues/1482.
-        # ("core.control_flow.run_conditions.multiplier", {"my_input": 0.5}),
-        # ("core.control_flow.run_conditions.multiplier_2", {"my_input": 10}),
-        # ("core.control_flow.run_conditions.multiplier_3", {"my_input": 5}),
-        # ("core.control_flow.run_conditions.basic_boolean_wf", {"seed": 5}),
-        # ("core.control_flow.run_conditions.bool_input_wf", {"b": True}),
-        # ("core.control_flow.run_conditions.nested_conditions", {"my_input": 0.4}),
-        # ("core.control_flow.run_conditions.consume_outputs", {"my_input": 0.4, "seed": 7}),
-        # ("core.control_flow.run_merge_sort.merge_sort", {"numbers": [5, 4, 3, 2, 1], "count": 5}),
-        ("core.control_flow.subworkflows.parent_wf", {"a": 3}),
-        ("core.control_flow.subworkflows.nested_parent_wf", {"a": 3}),
+        # ("core.control_flow.chain_tasks.chain_tasks_wf", {}),
+        # ("core.control_flow.dynamics.wf", {"s1": "Pear", "s2": "Earth"}),
+        # ("core.control_flow.map_task.my_map_workflow", {"a": [1, 2, 3, 4, 5]}),
+        # # Workflows that use nested executions cannot be launched via flyteremote.
+        # # This issue is being tracked in https://github.com/flyteorg/flyte/issues/1482.
+        # # ("core.control_flow.run_conditions.multiplier", {"my_input": 0.5}),
+        # # ("core.control_flow.run_conditions.multiplier_2", {"my_input": 10}),
+        # # ("core.control_flow.run_conditions.multiplier_3", {"my_input": 5}),
+        # # ("core.control_flow.run_conditions.basic_boolean_wf", {"seed": 5}),
+        # # ("core.control_flow.run_conditions.bool_input_wf", {"b": True}),
+        # # ("core.control_flow.run_conditions.nested_conditions", {"my_input": 0.4}),
+        # # ("core.control_flow.run_conditions.consume_outputs", {"my_input": 0.4, "seed": 7}),
+        # # ("core.control_flow.run_merge_sort.merge_sort", {"numbers": [5, 4, 3, 2, 1], "count": 5}),
+        # ("core.control_flow.subworkflows.parent_wf", {"a": 3}),
+        # ("core.control_flow.subworkflows.nested_parent_wf", {"a": 3}),
         ("core.flyte_basics.basic_workflow.my_wf", {"a": 50, "b": "hello"}),
-        # Getting a 403 for the wikipedia image
-        # ("core.flyte_basics.files.rotate_one_workflow", {"in_image": "https://upload.wikimedia.org/wikipedia/commons/d/d2/Julia_set_%28C_%3D_0.285%2C_0.01%29.jpg"}),
-        ("core.flyte_basics.folders.download_and_rotate", {}),
-        ("core.flyte_basics.hello_world.my_wf", {}),
-        ("core.flyte_basics.lp.my_wf", {"val": 4}),
-        ("core.flyte_basics.lp.go_greet", {"day_of_week": "5", "number": 3, "am": True}),
-        ("core.flyte_basics.named_outputs.my_wf", {}),
         # # Getting a 403 for the wikipedia image
-        # # ("core.flyte_basics.reference_task.wf", {}),
-        ("core.type_system.custom_objects.wf", {"x": 10, "y": 20}),
-        # Enums are not supported in flyteremote
-        # ("core.type_system.enums.enum_wf", {"c": "red"}),
-        ("core.type_system.schema.df_wf", {"a": 42}),
-        ("core.type_system.typed_schema.wf", {}),
-        ("my.imperative.workflow.example", {"in1": "hello", "in2": "foo"}),
+        # # ("core.flyte_basics.files.rotate_one_workflow", {"in_image": "https://upload.wikimedia.org/wikipedia/commons/d/d2/Julia_set_%28C_%3D_0.285%2C_0.01%29.jpg"}),
+        # ("core.flyte_basics.folders.download_and_rotate", {}),
+        # ("core.flyte_basics.hello_world.my_wf", {}),
+        # ("core.flyte_basics.lp.my_wf", {"val": 4}),
+        # ("core.flyte_basics.lp.go_greet", {"day_of_week": "5", "number": 3, "am": True}),
+        # ("core.flyte_basics.named_outputs.my_wf", {}),
+        # # # Getting a 403 for the wikipedia image
+        # # # ("core.flyte_basics.reference_task.wf", {}),
+        # ("core.type_system.custom_objects.wf", {"x": 10, "y": 20}),
+        # # Enums are not supported in flyteremote
+        # # ("core.type_system.enums.enum_wf", {"c": "red"}),
+        # ("core.type_system.schema.df_wf", {"a": 42}),
+        # ("core.type_system.typed_schema.wf", {}),
+        # ("my.imperative.workflow.example", {"in1": "hello", "in2": "foo"}),
     ],
 }
 


### PR DESCRIPTION
This PR uses `click` to improve the way we handle parameters passed to the functional tests script. 

We get a usage description flag for free:
```
❯ boilerplate/flyte/end2end/run-tests.py --help
Usage: run-tests.py [OPTIONS] FLYTESNACKS_RELEASE_TAG PRIORITIES CONFIG_FILE

Options:
  --return_non_zero_on_failure    Return a non-zero exit status if any
                                  workflow fails
  --terminate_workflow_on_failure
                                  Abort failing workflows upon exit
  --help                          Show this message and exit.
```

You'll notice that I added 2 boolean flags:
1. `--return_non_zero_on_failure`: we already use to fail the script (i.e. return a non-zero exit code) when any workflow execution fails and 
2. `--terminate_workflow_on_failure`: this is a new flag which is going to abort any workflow that didn't succeed.

One caveat: once this is merged we'll need to modify the invocation of the script in all places where it's currently being used, as can be shown in the change to `end2end.sh`.

Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>