### PR TITLE
Fix broken go install for pflags because of replace directives

### DIFF
--- a/boilerplate/flyte/golang_test_targets/download_tooling.sh
+++ b/boilerplate/flyte/golang_test_targets/download_tooling.sh
@@ -17,7 +17,7 @@ set -e
 # In the format of "<cli>:<package>" or ":<package>" if no cli
 tools=(
   "github.com/vektra/mockery/cmd/mockery"
-  "github.com/flyteorg/flytestdlib/cli/pflags@latest"
+  "github.com/flyteorg/flytestdlib/cli/pflags"
   "github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
   "github.com/alvaroloes/enumer"
   "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

Due to addition of replace directive in this change 
https://github.com/flyteorg/flytestdlib/pull/119/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R101
pflags install is broken.

go install doesn't allow version based installation if the mod file contains replace directives.

https://github.com/golang/go/issues/44840

Testing done:

### Before the change
```
 sh boilerplate/flyte/golang_test_targets/download_tooling.sh      
Using temp directory /var/folders/fw/3_xpq9s53l10pj6s2j2fs0v40000gn/T/gotooling-XXX.wLyvHaFT
/var/folders/fw/3_xpq9s53l10pj6s2j2fs0v40000gn/T/gotooling-XXX.wLyvHaFT ~/boilerplate
Installing github.com/vektra/mockery/cmd/mockery
Installing github.com/flyteorg/flytestdlib/cli/pflags@latest
go install: github.com/flyteorg/flytestdlib/cli/pflags@latest (in github.com/flyteorg/flytestdlib@v0.4.15):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.

```

### After the change

```
sh boilerplate/flyte/golang_test_targets/download_tooling.sh
Using temp directory /var/folders/fw/3_xpq9s53l10pj6s2j2fs0v40000gn/T/gotooling-XXX.YAIXPJMQ
/var/folders/fw/3_xpq9s53l10pj6s2j2fs0v40000gn/T/gotooling-XXX.YAIXPJMQ ~/boilerplate
Installing github.com/vektra/mockery/cmd/mockery
Installing github.com/flyteorg/flytestdlib/cli/pflags
Installing github.com/golangci/golangci-lint/cmd/golangci-lint@latest
Installing github.com/alvaroloes/enumer
Installing github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
```