### PR TITLE
Update incorrect URL

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 This project is governed by [flyteorg's code of
-conduct](https://github.com/flyteorg/code-of-conduct). All contributors
+conduct](https://lfprojects.org/policies/code-of-conduct/). All contributors
 and participants agree to abide by its terms.


### PR DESCRIPTION
The current URL returns a 404.
Updated the code of conduct URL to be consistent with other repositories in flyteorg.