### PR TITLE
Fix name of non-P0 tests

### DIFF
--- a/boilerplate/flyte/end2end/run-tests.py
+++ b/boilerplate/flyte/end2end/run-tests.py
@@ -75,7 +75,7 @@ FLYTESNACKS_WORKFLOW_GROUPS: Mapping[str, List[Tuple[str, dict]]] = {
     "integrations-pandera_examples": [
         ("pandera_plugin.basic_schema_example.process_data", {}),
         # TODO: investigate type mismatch float -> numpy.float64
-        ("pandera_plugin.validating_and_testing_ml_pipelines.pipeline", {"data_random_state": 42, "model_random_state": 99}),
+        # ("pandera_plugin.validating_and_testing_ml_pipelines.pipeline", {"data_random_state": 42, "model_random_state": 99}),
     ],
     "integrations-modin_examples": [
         ("modin_plugin.knn_classifier.pipeline", {}),

--- a/boilerplate/flyte/end2end/run-tests.py
+++ b/boilerplate/flyte/end2end/run-tests.py
@@ -61,33 +61,33 @@ FLYTESNACKS_WORKFLOW_GROUPS: Mapping[str, List[Tuple[str, dict]]] = {
         #("my.imperative.workflow.example", {"in1": "hello", "in2": "foo"}),
     ],
     "integrations-k8s-spark": [
-        ("k8s_spark.pyspark_pi.my_spark", {"triggered_date": datetime.datetime.now()}),
+        ("k8s_spark_plugin.pyspark_pi.my_spark", {"triggered_date": datetime.datetime.now()}),
     ],
     "integrations-kfpytorch": [
-        ("kfpytorch.pytorch_mnist.pytorch_training_wf", {}),
+        ("kfpytorch_plugin.pytorch_mnist.pytorch_training_wf", {}),
     ],
     "integrations-kftensorflow": [
-        ("kftensorflow.tf_mnist.mnist_tensorflow_workflow", {}),
+        ("kftensorflow_plugin.tf_mnist.mnist_tensorflow_workflow", {}),
     ],
     # "integrations-pod": [
     #     ("pod.pod.pod_workflow", {}),
     # ],
     "integrations-pandera_examples": [
-        ("pandera_examples.basic_schema_example.process_data", {}),
+        ("pandera_plugin.basic_schema_example.process_data", {}),
         # TODO: investigate type mismatch float -> numpy.float64
-        # ("pandera_examples.validating_and_testing_ml_pipelines.pipeline", {"data_random_state": 42, "model_random_state": 99}),
+        ("pandera_plugin.validating_and_testing_ml_pipelines.pipeline", {"data_random_state": 42, "model_random_state": 99}),
     ],
     "integrations-modin_examples": [
-        ("modin_examples.knn_classifier.pipeline", {}),
+        ("modin_plugin.knn_classifier.pipeline", {}),
     ],
     "integrations-papermilltasks": [
-        ("papermilltasks.simple.nb_to_python_wf", {"f": 3.1415926535}),
+        ("papermill_plugin.simple.nb_to_python_wf", {"f": 3.1415926535}),
     ],
     "integrations-greatexpectations": [
-        ("greatexpectations.task_example.simple_wf", {}),
-        ("greatexpectations.task_example.file_wf", {}),
-        ("greatexpectations.task_example.schema_wf", {}),
-        ("greatexpectations.task_example.runtime_wf", {}),
+        ("greatexpectations_plugin.task_example.simple_wf", {}),
+        ("greatexpectations_plugin.task_example.file_wf", {}),
+        ("greatexpectations_plugin.task_example.schema_wf", {}),
+        ("greatexpectations_plugin.task_example.runtime_wf", {}),
     ],
 }
 


### PR DESCRIPTION
In https://github.com/flyteorg/boilerplate/pull/79 we missed the correct names of all non-P0 tests. This PR fixes them.

Tested change in https://github.com/flyteorg/flyteadmin/pull/592.