### PR TITLE
Fix cluster-pool arg

### DIFF
--- a/boilerplate/flyte/end2end/run-tests.py
+++ b/boilerplate/flyte/end2end/run-tests.py
@@ -97,8 +97,8 @@ def execute_workflow(
         cluster_pool_name: Optional[str] = None,
 ):
     print(f"Fetching workflow={workflow_name} and version={version}")
-    wf = remote.fetch_workflow(name=workflow_name, version=version, cluster_pool=cluster_pool_name)
-    return remote.execute(wf, inputs=inputs, wait=False)
+    wf = remote.fetch_workflow(name=workflow_name, version=version)
+    return remote.execute(wf, inputs=inputs, wait=False, cluster_pool=cluster_pool_name)
 
 
 def executions_finished(executions_by_wfgroup: Dict[str, List[FlyteWorkflowExecution]]) -> bool:


### PR DESCRIPTION
I was unable to find a `fetch_workflow` that takes `cluster_pool` as a named argument, but it looks like [here](https://github.com/flyteorg/flyte/pull/4212/files#diff-2acf435024e5d5b3ed21338009787c192205f7d6585adf387b25fc2937dd1c52L95), this argument was intended to be passed to the `remote.execute()` call just below the `fetch_workflow()` call. Earlier today, [a fix](https://github.com/flyteorg/boilerplate/commit/9e95508de5c475a63620a6dfbf836d12221b0d83#diff-2acf435024e5d5b3ed21338009787c192205f7d6585adf387b25fc2937dd1c52R100) was implemented adding the `cluster_pool` here.

Tested this change on the [`custom-trigger` pipeline](https://buildkite.com/unionai/custom-trigger/builds/186#_) in the cloud repo and it worked as intended.